### PR TITLE
back to previous

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,8 +23,7 @@ Imports:
     stringr,
     stringi,
     R.utils,
-    plyr,
-    DBI (>= 0.4.1)
+    plyr
 Suggests:
     adegenet,
     ade4,


### PR DESCRIPTION
not a DBI problem but a devtools and appveyor problem, lets wait for them to fix the bug...

recent build error: "there is no package called 'Rcpp'" · Issue #70 · krlmlr/r-appveyor
https://github.com/krlmlr/r-appveyor/issues/70

install_deps() fails to install all dependencies on Windows · Issue #1246 · hadley/devtools
https://github.com/hadley/devtools/issues/1246